### PR TITLE
Force dark mode regardless of device color scheme preference

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* Force dark mode: apply dark: styles based on the .dark class (always set
+   on <html>) instead of the user's prefers-color-scheme setting. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --background-image-gradient-radial: radial-gradient(var(--tw-gradient-stops));
   --background-image-gradient-conic: conic-gradient(


### PR DESCRIPTION
Tailwind v4's dark: variant defaults to the prefers-color-scheme media
query, so users on light mode devices got broken light styles even
though <html> is hardcoded with class="dark". Define a class-based
dark variant so dark: styles always apply.

https://claude.ai/code/session_01SmVnRJt39DfkBGV9mSEe5z